### PR TITLE
Update docs for orchestrator build process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,9 @@ dataset-harmonizer/
 
 * The **Node.js backend** runs directly on the host and manages user accounts.
 * The **web server** and **frontend** live in a Docker container.
-* Each job spawns a dedicated **worker container**, ensuring per-session isolation.
+* At startup the orchestrator builds the required images from the provided Dockerfiles.
+* Each job spawns a dedicated **worker container** using `docker compose` so that sessions remain isolated.
+* A tracking mechanism records which session owns which container, allowing multiple users to run jobs in parallel.
 * The orchestrator removes containers when processing completes.
 
 ---

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ dataset-harmonizer/
 3. Forward progress to the browser.
 4. Provide the harmonized dataset and logs.
 
+## Deployment
+
+When the server boots, the orchestrator automatically builds the necessary Docker images from the provided `Dockerfile`. Worker containers are then launched on demand through `docker compose`. A session tracker maps containers to user sessions so that multiple jobs can run in parallel and each container can be cleaned up correctly once its job finishes.
+
 ## Technologies
 
 | Area       | Tech                        |


### PR DESCRIPTION
## Summary
- document the build-on-startup orchestration approach
- outline container tracking in README and AGENTS

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875fd2fc95483339266a79429e0f18c