### PR TITLE
Add helper scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# install.sh - setup Dataset Harmonizer webserver dependencies
+
+set -e
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+WEB_DIR="$SCRIPT_DIR/dataset-harmonizer/webserver"
+
+echo "Installing Node.js dependencies..."
+cd "$WEB_DIR"
+npm install
+
+echo "Installation complete."

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# start.sh - launch Dataset Harmonizer web server
+
+set -e
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+WEB_DIR="$SCRIPT_DIR/dataset-harmonizer/webserver"
+
+cd "$WEB_DIR"
+node server.js

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# update.sh - update repository and dependencies
+
+set -e
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "Pulling latest changes..."
+git pull
+
+cd dataset-harmonizer/webserver
+npm install
+
+echo "Update complete."


### PR DESCRIPTION
## Summary
- add `install.sh` for installing Node dependencies
- add `start.sh` to launch the web server
- add `update.sh` for pulling latest changes and reinstalling deps

## Testing
- `npm install --silent` *(fails: UNMET DEPENDENCY express-session@^1.17.3 etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68762229ed5c8333a14286e5cad7517e