### PR TITLE
Fix webserver install

### DIFF
--- a/dataset-harmonizer/webserver/package.json
+++ b/dataset-harmonizer/webserver/package.json
@@ -4,7 +4,7 @@
   "main": "server.js",
   "dependencies": {
     "express": "^4.18.2",
-    "multer": "^1.4.5",
+    "multer": "1.4.5-lts.2",
     "express-session": "^1.17.3",
     "uuid": "^9.0.0"
   }


### PR DESCRIPTION
## Summary
- fix install script failing due to invalid `multer` version

## Testing
- `npm install`
- `./start.sh`

------
https://chatgpt.com/codex/tasks/task_e_68762493bfc4833387e0a6e256c6c0e9