### PR TITLE
Fix container cleanup

### DIFF
--- a/dataset-harmonizer/webserver/orchestrator.js
+++ b/dataset-harmonizer/webserver/orchestrator.js
@@ -16,7 +16,8 @@ class Orchestrator extends EventEmitter {
   startJob(userId, jobId, params) {
     const containerName = `${userId}_processing_${jobId}`;
     const composeFile = path.join(__dirname, 'worker-compose.yml');
-    const args = ['compose', '-f', composeFile, 'run', '--rm', '--name', containerName, 'worker', ...params];
+    // run the worker container and let this class handle cleanup
+    const args = ['compose', '-f', composeFile, 'run', '--name', containerName, 'worker', ...params];
     const proc = spawn('docker', args);
     this.jobs.set(jobId, proc);
 


### PR DESCRIPTION
## Summary
- don't auto-remove worker container on run so orchestrator can remove it itself

## Testing
- `node dataset-harmonizer/webserver/server.js` *(fails: spawn docker ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6876268196d88333a222baf280a76058