### PR TITLE
Fix zip step to use AdmZip

### DIFF
--- a/dataset-harmonizer/webserver/orchestrator.js
+++ b/dataset-harmonizer/webserver/orchestrator.js
@@ -1,6 +1,7 @@
-const { spawn, spawnSync } = require('child_process');
+const { spawn } = require('child_process');
 const path = require('path');
 const EventEmitter = require('events');
+const AdmZip = require('adm-zip');
 
 class Orchestrator extends EventEmitter {
   constructor() {
@@ -47,7 +48,9 @@ class Orchestrator extends EventEmitter {
       const outDir = path.join(__dirname, '..', 'outputs', jobId);
       const zipFile = path.join(__dirname, '..', 'outputs', `${jobId}.zip`);
       try {
-        spawnSync('zip', ['-r', zipFile, '.'], { cwd: outDir });
+        const zip = new AdmZip();
+        zip.addLocalFolder(outDir, '');
+        zip.writeZip(zipFile);
       } catch (err) {
         this.emit('log', { jobId, line: `Failed to zip output: ${err.message}` });
       }


### PR DESCRIPTION
## Summary
- use AdmZip in orchestrator to create a zip archive without relying on the system `zip` command

## Testing
- `npm ls --depth=0`
- `node -e "require('./orchestrator'); console.log('ok');"`
- `python -m py_compile dataset-harmonizer/harmonizer/dataset_harmonizer.py`


------
https://chatgpt.com/codex/tasks/task_e_687639d7001c8333b0560f8e683c090b