### PR TITLE
Add Dataset Pipe step examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,16 @@ When the server boots, the orchestrator automatically builds the necessary Docke
 
 - **Dry-run mode** – test run without modifying data
 - **Multi-threading** (planned)
+
+## Dataset Pipe Roadmap
+
+Example Dockerfiles for each processing step are provided under `dataset-pipe/`:
+
+1. Frame Extraction
+2. Deduplication
+3. Filtering
+4. Upscaling & QC
+5. Cropping
+6. Annotation
+7. Character Classification
+8. Packaging

--- a/dataset-pipe/README.md
+++ b/dataset-pipe/README.md
@@ -1,0 +1,16 @@
+# Dataset Pipe
+
+This directory contains example Dockerfiles for each planned processing step. Each step runs in its own container.
+
+```
+frame-extraction/          # ffmpeg grabs frames from video
+deduplication/             # remove near duplicates
+filtering/                 # flatten folders and drop unwanted shots
+upscaling-qc/              # upscale images and run quality checks
+cropping/                  # crop faces using detection models
+annotation/                # generate captions with WD14 tagger
+character-classification/  # group images by character traits
+packaging/                 # create final ZIP packages
+```
+
+Each folder includes a basic `Dockerfile` demonstrating the expected environment for that stage.

--- a/dataset-pipe/annotation/Dockerfile
+++ b/dataset-pipe/annotation/Dockerfile
@@ -1,0 +1,6 @@
+# Example Dockerfile for annotation step
+FROM python:3.9-slim
+WORKDIR /app
+COPY . /app
+RUN pip install Pillow
+CMD ["python", "annotate.py"]

--- a/dataset-pipe/character-classification/Dockerfile
+++ b/dataset-pipe/character-classification/Dockerfile
@@ -1,0 +1,6 @@
+# Example Dockerfile for character classification step
+FROM python:3.9-slim
+WORKDIR /app
+COPY . /app
+RUN pip install Pillow scikit-learn
+CMD ["python", "classify.py"]

--- a/dataset-pipe/cropping/Dockerfile
+++ b/dataset-pipe/cropping/Dockerfile
@@ -1,0 +1,6 @@
+# Example Dockerfile for cropping step
+FROM python:3.9-slim
+WORKDIR /app
+COPY . /app
+RUN pip install Pillow
+CMD ["python", "crop.py"]

--- a/dataset-pipe/deduplication/Dockerfile
+++ b/dataset-pipe/deduplication/Dockerfile
@@ -1,0 +1,6 @@
+# Example Dockerfile for deduplication step
+FROM python:3.9-slim
+WORKDIR /app
+COPY . /app
+RUN pip install imagehash Pillow
+CMD ["python", "deduplicate.py"]

--- a/dataset-pipe/filtering/Dockerfile
+++ b/dataset-pipe/filtering/Dockerfile
@@ -1,0 +1,6 @@
+# Example Dockerfile for filtering step
+FROM python:3.9-slim
+WORKDIR /app
+COPY . /app
+RUN pip install Pillow
+CMD ["python", "filter.py"]

--- a/dataset-pipe/frame-extraction/Dockerfile
+++ b/dataset-pipe/frame-extraction/Dockerfile
@@ -1,0 +1,6 @@
+# Example Dockerfile for frame extraction step
+FROM python:3.9-slim
+RUN apt-get update && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
+WORKDIR /data
+# Placeholder command
+CMD ["ffmpeg", "-version"]

--- a/dataset-pipe/packaging/Dockerfile
+++ b/dataset-pipe/packaging/Dockerfile
@@ -1,0 +1,5 @@
+# Example Dockerfile for packaging step
+FROM python:3.9-slim
+WORKDIR /app
+COPY . /app
+CMD ["zip", "-r", "/data/output.zip", "/data"]

--- a/dataset-pipe/upscaling-qc/Dockerfile
+++ b/dataset-pipe/upscaling-qc/Dockerfile
@@ -1,0 +1,6 @@
+# Example Dockerfile for upscaling and quality control step
+FROM python:3.9-slim
+WORKDIR /app
+COPY . /app
+RUN pip install Pillow
+CMD ["python", "upscale.py"]


### PR DESCRIPTION
## Summary
- add directories for each dataset pipe processing stage
- provide an example Dockerfile in each folder
- document the Dataset Pipe roadmap in README
- add README for dataset-pipe directory

## Testing
- `python3 -m py_compile dataset-harmonizer/harmonizer/dataset_harmonizer.py`
- `node -v`
- `npm list --depth=0`

------
https://chatgpt.com/codex/tasks/task_e_68763ea583988333b8ddee8034984408