### PR TITLE
Add docker-compose for pipeline steps

### DIFF
--- a/dataset_pipe/annotation/docker-compose.yml
+++ b/dataset_pipe/annotation/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  worker:
+    build: .
+    volumes:
+      - ../../dataset-harmonizer/uploads:/uploads
+      - ../../dataset-harmonizer/outputs:/outputs
+      - ../../dataset-harmonizer/logs:/logs
+    environment:
+      - PROGRESS=1
+    command: ["python", "annotate.py"]

--- a/dataset_pipe/character-classification/docker-compose.yml
+++ b/dataset_pipe/character-classification/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  worker:
+    build: .
+    volumes:
+      - ../../dataset-harmonizer/uploads:/uploads
+      - ../../dataset-harmonizer/outputs:/outputs
+      - ../../dataset-harmonizer/logs:/logs
+    environment:
+      - PROGRESS=1
+    command: ["python", "classify.py"]

--- a/dataset_pipe/cropping/docker-compose.yml
+++ b/dataset_pipe/cropping/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  worker:
+    build: .
+    volumes:
+      - ../../dataset-harmonizer/uploads:/uploads
+      - ../../dataset-harmonizer/outputs:/outputs
+      - ../../dataset-harmonizer/logs:/logs
+    environment:
+      - PROGRESS=1
+    command: ["python", "crop.py"]

--- a/dataset_pipe/deduplication/docker-compose.yml
+++ b/dataset_pipe/deduplication/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  worker:
+    build: .
+    volumes:
+      - ../../dataset-harmonizer/uploads:/uploads
+      - ../../dataset-harmonizer/outputs:/outputs
+      - ../../dataset-harmonizer/logs:/logs
+    environment:
+      - PROGRESS=1
+    command: ["python", "deduplicate.py"]

--- a/dataset_pipe/filtering/docker-compose.yml
+++ b/dataset_pipe/filtering/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  worker:
+    build: .
+    volumes:
+      - ../../dataset-harmonizer/uploads:/uploads
+      - ../../dataset-harmonizer/outputs:/outputs
+      - ../../dataset-harmonizer/logs:/logs
+    environment:
+      - PROGRESS=1
+    command: ["python", "filter.py"]

--- a/dataset_pipe/frame-extraction/docker-compose.yml
+++ b/dataset_pipe/frame-extraction/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  worker:
+    build: .
+    volumes:
+      - ../../dataset-harmonizer/uploads:/uploads
+      - ../../dataset-harmonizer/outputs:/outputs
+      - ../../dataset-harmonizer/logs:/logs
+    environment:
+      - PROGRESS=1
+    command: ["ffmpeg", "-version"]

--- a/dataset_pipe/packaging/docker-compose.yml
+++ b/dataset_pipe/packaging/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  worker:
+    build: .
+    volumes:
+      - ../../dataset-harmonizer/uploads:/uploads
+      - ../../dataset-harmonizer/outputs:/outputs
+      - ../../dataset-harmonizer/logs:/logs
+    environment:
+      - PROGRESS=1
+    command: ["zip", "-r", "/data/output.zip", "/data"]

--- a/dataset_pipe/upscaling-qc/docker-compose.yml
+++ b/dataset_pipe/upscaling-qc/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  worker:
+    build: .
+    volumes:
+      - ../../dataset-harmonizer/uploads:/uploads
+      - ../../dataset-harmonizer/outputs:/outputs
+      - ../../dataset-harmonizer/logs:/logs
+    environment:
+      - PROGRESS=1
+    command: ["python", "upscale.py"]


### PR DESCRIPTION
## Summary
- add `docker-compose.yml` files in each dataset pipeline step
- mount shared uploads, outputs, and logs
- run step-specific commands with `PROGRESS` env variable

## Testing
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68765c8498ac8333b114130c31d3d1f2