### PR TITLE
Link pipeline to orchestrator

### DIFF
--- a/dataset-harmonizer/webserver/orchestrator.js
+++ b/dataset-harmonizer/webserver/orchestrator.js
@@ -11,7 +11,8 @@ class Orchestrator extends EventEmitter {
 
   initialize() {
     // Build worker image on startup
-    this.runCommand('docker', ['build', '-t', 'dataset-worker', path.join(__dirname, '..', 'harmonizer')]);
+    const workerDir = path.join(__dirname, '..', '..', 'dataset_pipe');
+    this.runCommand('docker', ['build', '-t', 'dataset-worker', workerDir]);
   }
 
   startJob(userId, jobId, datasetName, params) {

--- a/dataset-harmonizer/webserver/public/app.js
+++ b/dataset-harmonizer/webserver/public/app.js
@@ -12,7 +12,12 @@ async function refreshLists() {
   uploadedList.innerHTML = '';
   data.uploaded.forEach(name => {
     const li = document.createElement('li');
-    li.innerHTML = `<label><input type="checkbox" value="${name}"> ${name}</label>`;
+    const btn = document.createElement('button');
+    btn.textContent = 'Start';
+    btn.dataset.name = name;
+    btn.addEventListener('click', () => startJob(name));
+    li.textContent = name + ' ';
+    li.appendChild(btn);
     uploadedList.appendChild(li);
   });
   finishedList.innerHTML = '';
@@ -28,15 +33,24 @@ window.addEventListener('load', refreshLists);
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
   const formData = new FormData(form);
+  await fetch('/upload', { method: 'POST', body: formData });
+  form.reset();
+  refreshLists();
+});
+
+async function startJob(name) {
   progressSection.classList.remove('hidden');
   bar.style.width = '0%';
-  statusText.textContent = 'Uploading...';
+  statusText.textContent = 'Starting...';
   log.textContent = '';
-
-  const res = await fetch('/upload', { method: 'POST', body: formData });
+  const res = await fetch('/start', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
   const data = await res.json();
   listenProgress(data.jobId);
-});
+}
 
 function listenProgress(jobId) {
   const source = new EventSource(`/progress/${jobId}`);

--- a/dataset-harmonizer/webserver/public/index.html
+++ b/dataset-harmonizer/webserver/public/index.html
@@ -13,25 +13,13 @@
       <ul id="uploaded-list"></ul>
     </div>
     <div class="main container">
-      <h1>Dataset Harmonizer</h1>
+      <h1>Dataset Pipeline</h1>
       <form id="upload-form">
       <div class="form-group">
-        <label for="dataset">Dataset ZIP</label>
+        <label for="dataset">Dataset File (video or zip)</label>
         <input type="file" id="dataset" name="dataset" required>
       </div>
-      <div class="form-group">
-        <label for="output_format">Output Format</label>
-        <select id="output_format" name="output_format">
-          <option value="png">PNG</option>
-          <option value="jpg">JPG</option>
-          <option value="webp">WEBP</option>
-        </select>
-      </div>
-      <div class="form-group inline">
-        <label><input type="checkbox" id="auto_resize" name="auto_resize"> Auto Resize</label>
-        <label><input type="checkbox" id="padding" name="padding"> Padding</label>
-      </div>
-      <button type="submit">Start Harmonization</button>
+      <button type="submit">Upload</button>
       </form>
       <div id="progress" class="hidden">
         <div class="progress-bar"><div class="bar" id="bar"></div></div>

--- a/dataset-harmonizer/webserver/server.js
+++ b/dataset-harmonizer/webserver/server.js
@@ -2,9 +2,9 @@ const express = require('express');
 const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
-const AdmZip = require('adm-zip');
 const session = require('express-session');
 const { v4: uuidv4 } = require('uuid');
+const AdmZip = require('adm-zip');
 const routes = require('./routes');
 const Orchestrator = require('./orchestrator');
 
@@ -29,30 +29,39 @@ let finishedDatasets = [];
 const jobFiles = new Map();
 
 app.post('/upload', upload.single('dataset'), (req, res) => {
+  const fileName = path.parse(req.file.originalname).base;
+  const destPath = path.join(uploadsDir, fileName);
+  fs.renameSync(req.file.path, destPath);
+  if (!uploadedDatasets.includes(fileName)) {
+    uploadedDatasets.push(fileName);
+  }
+  res.json({ name: fileName });
+});
+
+app.post('/start', async (req, res) => {
+  const { name } = req.body;
   const userId = req.session.userId || uuidv4();
   req.session.userId = userId;
 
   const jobId = uuidv4();
-  const datasetName = path.parse(req.file.originalname).name;
-  const extractDir = path.join(uploadsDir, datasetName);
-  fs.mkdirSync(extractDir, { recursive: true });
+  const srcPath = path.join(uploadsDir, name);
+  let args;
+  if (name.toLowerCase().endsWith('.zip')) {
+    const tmpDir = path.join(uploadsDir, jobId);
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      const zip = new AdmZip(srcPath);
+      zip.extractAllTo(tmpDir, true);
+    } catch (err) {
+      return res.status(400).json({ error: 'Failed to extract zip' });
+    }
+    args = ['--images', `/uploads/${jobId}`, `/outputs/${jobId}`];
+  } else {
+    args = ['--video', `/uploads/${name}`, `/outputs/${jobId}`];
+  }
 
-  const zip = new AdmZip(req.file.path);
-  zip.extractAllTo(extractDir, true);
-  fs.unlinkSync(req.file.path);
-  uploadedDatasets.push(datasetName);
-
-  const args = [
-    `/uploads/${datasetName}`,
-    `/outputs/${jobId}`,
-    '--dataset_name', req.body.dataset_name || 'dataset',
-    '--output_format', req.body.output_format || 'png',
-  ];
-  if (req.body.auto_resize) args.push('--auto_resize');
-  if (req.body.padding) args.push('--padding');
-
-  jobFiles.set(jobId, datasetName);
-  orchestrator.startJob(userId, jobId, datasetName, args);
+  jobFiles.set(jobId, name);
+  orchestrator.startJob(userId, jobId, name, args);
 
   res.json({ jobId });
 });

--- a/dataset-harmonizer/webserver/worker-compose.yml
+++ b/dataset-harmonizer/webserver/worker-compose.yml
@@ -8,4 +8,4 @@ services:
       - ../logs:/logs
     environment:
       - PROGRESS=1
-    command: ["python", "/app/dataset_harmonizer.py"]
+    command: ["python", "-m", "dataset_pipe.pipeline.run_pipeline"]

--- a/dataset_pipe/Dockerfile
+++ b/dataset_pipe/Dockerfile
@@ -1,0 +1,6 @@
+# Dockerfile for dataset pipeline worker
+FROM python:3.9-slim
+WORKDIR /app
+COPY . /app/dataset_pipe
+RUN pip install --no-cache-dir pillow imagehash
+ENTRYPOINT ["python", "-m", "dataset_pipe.pipeline.run_pipeline"]

--- a/dataset_pipe/README.md
+++ b/dataset_pipe/README.md
@@ -23,6 +23,15 @@ pipeline under `pipeline/`.  The code was adapted from the
 `Pipeline` runner.  It mirrors the eight stages listed above and can be
 used without Docker for quick experiments.
 
+`python -m dataset_pipe.pipeline.run_pipeline` offers a small CLI wrapper that
+prints progress messages when the `PROGRESS` environment variable is set.
+You can process either a video or a folder of images:
+
+```
+python -m dataset_pipe.pipeline.run_pipeline --video input.mp4 output_dir
+python -m dataset_pipe.pipeline.run_pipeline --images images/ output_dir
+```
+
 Example usage:
 
 ```python
@@ -33,7 +42,7 @@ pipe = Pipeline(
     output_dir=Path('output'),
     work_dir=Path('work')
 )
-pipe.run(Path('video.mp4'))
+pipe.run(Path('video.mp4'))  # or pipe.run(None, images_dir=Path('images'))
 ```
 
 See the individual modules under `pipeline/steps/` for details.

--- a/dataset_pipe/pipeline/logging_utils.py
+++ b/dataset_pipe/pipeline/logging_utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 from datetime import datetime
 
@@ -34,13 +35,20 @@ logger.addHandler(handler)
 logger.propagate = False
 
 
+PROGRESS_ENV = os.getenv("PROGRESS")
+
+
 def log_step(step: str) -> None:
     logger.dsk(step)
+    if PROGRESS_ENV:
+        print(step, flush=True)
 
 
 def log_progress(prefix: str, count: int, total: int) -> None:
     """Log a progress message of the form ``'<prefix> count/total'``."""
     logger.dsk(f"{prefix} {count}/{total}")
+    if PROGRESS_ENV:
+        print(f"PROGRESS {count} {total}", flush=True)
 
 
 def rotate_log(job_name: str) -> None:

--- a/dataset_pipe/pipeline/run_pipeline.py
+++ b/dataset_pipe/pipeline/run_pipeline.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""CLI entrypoint for the Dataset Pipe pipeline."""
+
+from pathlib import Path
+import argparse
+from .pipeline_runner import Pipeline
+from .logging_utils import rotate_log
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the dataset pipeline")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--video", help="Input video file")
+    group.add_argument("--images", help="Directory with input images")
+    parser.add_argument("output", help="Output directory for results")
+    parser.add_argument("--work", default="/tmp/work", help="Working directory")
+    parser.add_argument("--trigger_word", default="name")
+    parser.add_argument("--fps", type=int, default=1)
+    parser.add_argument("--skip_deduplication", action="store_true")
+    parser.add_argument("--skip_filtering", action="store_true")
+    parser.add_argument("--skip_upscaling", action="store_true")
+    parser.add_argument("--skip_cropping", action="store_true")
+    parser.add_argument("--skip_annotation", action="store_true")
+    parser.add_argument("--skip_classification", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    job_name = Path(args.output).name
+    rotate_log(job_name)
+    pipe = Pipeline(Path("."), Path(args.output), Path(args.work))
+    pipe.run(
+        Path(args.video) if args.video else None,
+        images_dir=Path(args.images) if args.images else None,
+        trigger_word=args.trigger_word,
+        progress_cb=None,
+        fps=args.fps,
+        skip_deduplication=args.skip_deduplication,
+        skip_filtering=args.skip_filtering,
+        skip_upscaling=args.skip_upscaling,
+        skip_cropping=args.skip_cropping,
+        skip_annotation=args.skip_annotation,
+        skip_classification=args.skip_classification,
+    )
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- allow progress to be emitted to STDOUT when `PROGRESS` is set
- add CLI runner for dataset pipeline
- build worker image from `dataset_pipe`
- adjust webserver to accept video uploads
- use pipeline runner inside worker container
- simplify frontend
- allow image directories as input and start jobs on demand

## Testing
- `python -m compileall -q dataset_pipe/pipeline`
- `npm install`
- `npm ls`


------
https://chatgpt.com/codex/tasks/task_e_6876601e43cc8333b7f5376ff76fb1ff